### PR TITLE
Fix sorting bug in Classement view

### DIFF
--- a/src/views/Classement.vue
+++ b/src/views/Classement.vue
@@ -40,7 +40,7 @@ export default {
   },
   computed: {
     top20() {
-      return this.tracks
+      return [...this.tracks]
         .sort((a, b) => parseFloat(b.note) - parseFloat(a.note))
         .slice(0, 20);
     }


### PR DESCRIPTION
## Summary
- prevent mutation of `tracks` when computing top 20 ranked songs

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526c515f2c83279aacff39fec8af0d